### PR TITLE
fix - FloatMenuItem 에서 onClick props의 default 값 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,10 @@ import styled from '@emotion/styled';
 function App(): ReactElement {
   const renderFloatButton = (direction: Direction) => (
     <FloatingGroup size={Size.REGULAR} direction={direction}>
-      <FloatMenuItemButton icon={<Twitter size="50%" />} buttonColor="#00ACEE" />
-      <FloatMenuItemButton icon={<Instagram size="50%" />} buttonColor="#4f5bd5" />
-      <FloatMenuItemButton icon={<Facebook size="50%" />} buttonColor="#3B5998" />
-      <FloatMenuItemButton icon={<Share size="50%" />} buttonColor="#16dbc2" />
+      <FloatMenuItemButton icon={<Twitter size="50%" />} buttonColor="#00ACEE" onClick={() => alert('Twitter')} />
+      <FloatMenuItemButton icon={<Instagram size="50%" />} buttonColor="#4f5bd5" onClick={() => alert('Instagram')} />
+      <FloatMenuItemButton icon={<Facebook size="50%" />} buttonColor="#3B5998" onClick={() => alert('Facebook')} />
+      <FloatMenuItemButton icon={<Share size="50%" />} buttonColor="#16dbc2" onClick={() => alert('Share')} />
     </FloatingGroup>
   );
 

--- a/src/FloatButton/FloatMenuItemButton.tsx
+++ b/src/FloatButton/FloatMenuItemButton.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 function FloatMenuItemButton(props: Props): ReactElement {
-  const { containerStyle, icon = 'icon', buttonColor = '#ffffff', onClick = () => console.log('Clicked!') } = props;
+  const { containerStyle, icon = 'icon', buttonColor = '#ffffff', onClick } = props;
 
   return (
     <Container style={containerStyle} onClick={onClick} buttonColor={buttonColor}>


### PR DESCRIPTION
## Preview
![화면 기록 2021-03-21 오전 2 24 33](https://user-images.githubusercontent.com/31176502/111880423-dd1fc280-89ee-11eb-9a59-0ccc64b95622.gif)

## What I Did
원래 하기로 했던 `메뉴의 아이템 별 onClick props 추가` 기능 구현이 이미 되어있었습니다.
따라서 이외의 수정이 필요한 부분을 수정했습니다.
- `FloatMenuItemButton.tsx` : props로 받는 부분인 `onClick`
 원래 `onClick= () => console.log('Clicked')`로 함수 리턴 값을 onClick의 default value로 가지도록 했던 부분을 아래처럼 default value가 없는 상태로 수정했습니다.
  ```
  function FloatMenuItemButton(props: Props): ReactElement {
    const { containerStyle, icon = 'icon', buttonColor = '#ffffff', onClick } = props;
  ```

- `App.tsx`: 예제 코드를 보여주는 코드에서 onClick 함수를 사용하는 코드를 추가했습니다.

  ```
   const renderFloatButton = (direction: Direction) => (
      <FloatingGroup size={Size.REGULAR} direction={direction}>
        <FloatMenuItemButton icon={<Twitter size="50%" />} buttonColor="#00ACEE" onClick={() => alert('Twitter')} />
        <FloatMenuItemButton icon={<Instagram size="50%" />} buttonColor="#4f5bd5" onClick={() => alert('Instagram')} />
        <FloatMenuItemButton icon={<Facebook size="50%" />} buttonColor="#3B5998" onClick={() => alert('Facebook')} />
        <FloatMenuItemButton icon={<Share size="50%" />} buttonColor="#16dbc2" onClick={() => alert('Share')} />
      </FloatingGroup>
    );
  ```
